### PR TITLE
Update BUS619 deploy URL

### DIFF
--- a/course-sites/descartes-courses.csv
+++ b/course-sites/descartes-courses.csv
@@ -1,0 +1,1 @@
+BUS619,https://uhm-itm.github.io/BUS619/


### PR DESCRIPTION
Automatically generated PR to update BUS619 course site URL to: https://uhm-itm.github.io/BUS619/