### PR TITLE
Update bus619 deploy URL

### DIFF
--- a/course-sites/descartes-courses.csv
+++ b/course-sites/descartes-courses.csv
@@ -1,1 +1,2 @@
 BUS619,https://uhm-itm.github.io/BUS619/
+bus619,https://uhm-itm.github.io/BUS619/


### PR DESCRIPTION
Automatically generated PR to update bus619 course site URL to: https://uhm-itm.github.io/BUS619/