### PR TITLE
Update bus619 deploy URL and description

### DIFF
--- a/course-sites/descartes-courses.csv
+++ b/course-sites/descartes-courses.csv
@@ -1,0 +1,1 @@
+bus619,https://uhm-itm.github.io/BUS619/,


### PR DESCRIPTION
Automatically generated PR to update bus619 course site URL to: https://uhm-itm.github.io/BUS619/ with description: 